### PR TITLE
Enable main.py python code support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+######################################### CPP ############################################
+
 # Prerequisites
 *.d
 
@@ -30,3 +32,169 @@
 *.exe
 *.out
 *.app
+
+
+######################################### PYTHON ############################################
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,7 +6,8 @@
 		"ms-vscode.cpptools-extension-pack",
 		"ms-vscode.cpptools",
 		"ms-vscode.cpptools-themes",
-		"Gruntfuggly.triggertaskonsave"
+		"Gruntfuggly.triggertaskonsave",
+		"ms-python.python"
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": []

--- a/.vscode/keybindings.json
+++ b/.vscode/keybindings.json
@@ -3,7 +3,13 @@
     {
         "key": "ctrl+shift+y",
         "command": "workbench.action.tasks.runTask",
-        "args": "Build and Run",
+        "args": "CPP Build and Run",
         "when": "resourceLangId == cpp"
+    },
+    {
+        "key": "ctrl+shift+y",
+        "command": "workbench.action.tasks.runTask",
+        "args": "PYTHON Run",
+        "when": "resourceLangId == python"
     }
 ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,7 +27,13 @@
                     "ignoreFailures": true
                 }
             ]
+        },
+        {
+            "name": "Python Debugger: Current File (Integrated Terminal)",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal"
         }
-
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,11 +29,17 @@
             ]
         },
         {
-            "name": "Python Debugger: Current File (Integrated Terminal)",
+            "name": "Python: pytest",
             "type": "debugpy",
             "request": "launch",
-            "program": "${file}",
-            "console": "integratedTerminal"
+            "module": "pytest",
+            "args": [
+                "${file}", // Path to your main.py script
+                "--disable-warnings", // Optional: Suppress pytest warnings
+                "-s"
+            ],
+            "console": "integratedTerminal",
+            "justMyCode": true
         }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,9 +4,12 @@
     // Following two are for that purpose.
     "files.autoSave": "off",
     "triggerTaskOnSave.tasks": {
-        "Build and Run": [
+        "CPP Build and Run": [
             "*.cpp", // <-- Glob pattern to specify which files should trigger the task
         ],
+        "PYTHON Run": [
+            "*.py"
+        ]
     },
     "editor.formatOnSave": true,
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,11 +3,11 @@
         //TODO: separate build and run tasks
         {
             "type": "cppbuild",
-            "label": "Build and Run",
+            "label": "CPP Build and Run",
             "command": "make",
             "args": [
                 "-f",
-                "../Makefile",
+                "../make_files/cpp/Makefile",
                 "run"
             ],
             "options": {
@@ -18,9 +18,30 @@
             ],
             "group": {
                 "kind": "build",
-                "isDefault": true
+                "isDefault": "*.cpp"
             },
             "detail": "Build main.cpp using make and run it."
+        },
+        {
+            "type": "process",
+            "label": "PYTHON Run",
+            "command": "make",
+            "args": [
+                "-f",
+                "../make_files/python/Makefile",
+                "run"
+            ],
+            "options": {
+                "cwd": "${fileDirname}"
+            },
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": "*.py"
+            },
+            "detail": "Build main.py using make and run it."
         }
     ],
     "version": "2.0.0"

--- a/1_parity/main.py
+++ b/1_parity/main.py
@@ -1,0 +1,18 @@
+import pytest
+
+# Function to test
+
+def parity(num):
+    ret = False
+    while num:
+        ret = ret ^ (num & 0x1)
+        num >>= 1
+    ret
+
+# Test cases
+def test_parity():
+    assert parity(7) == 1
+    assert parity(3) == 0
+
+if __name__ == "__main__":
+    pytest.main()

--- a/1_parity/main.py
+++ b/1_parity/main.py
@@ -7,10 +7,10 @@ def parity(num):
     while num:
         ret = ret ^ (num & 0x1)
         num >>= 1
-    ret
+    return ret
 
 # Test cases
-def test_parity():
+def testing_parity():
     assert parity(7) == 1
     assert parity(3) == 0
 

--- a/make_files/cpp/Makefile
+++ b/make_files/cpp/Makefile
@@ -46,4 +46,4 @@ clean:
 	rm -rf $(OBJDIR)
 
 # Phony targets
-.PHONY: all clean
+.PHONY: all run clean

--- a/make_files/python/Makefile
+++ b/make_files/python/Makefile
@@ -1,0 +1,28 @@
+# Define the Python interpreter and package manager
+PYTHON = python3
+PIP = pip3
+
+# Define the main Python script
+MAIN_SCRIPT = main.py
+
+# Define the test command (using pytest in this example)
+TEST_CMD = pytest
+
+
+# Rule to check if pytest is installed
+.PHONY: check-pytest
+check-pytest:
+	@$(PYTHON) -m pytest --version >/dev/null 2>&1 || (echo "pytest not found, installing..."; $(PIP) install pytest)
+
+# Default rule (run the main script)
+.PHONY: run
+run: check-pytest
+	$(TEST_CMD) $(MAIN_SCRIPT)
+
+# Clean rule (if you need it, for example to remove __pycache__)
+.PHONY: clean
+clean:
+	find . -type d -name "__pycache__" -exec rm -rf {} +
+
+# Phony targets
+.PHONY: run clean


### PR DESCRIPTION
Now main.py can be built and debugged just as main.cpp, on save and using the launch json task in vscode.
Test cases have to be duplicated across cpp and py files, but I don't see how it can be avoided.